### PR TITLE
Fixed installation path bug

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/fish
-set -x dir (pwd)
+set -x dir (cd (dirname (status --current-filename)); and pwd)
 set -x loc "$HOME/.local/lib/tasks"
 # moving directory to ~/.local/lib/
 mv $dir $loc


### PR DESCRIPTION
install.sh used pwd to get path, which didn't work when install.sh was
called from some other directory, this commit fixes that by changing
directory using status filename, and then returning the output of pwd.